### PR TITLE
Custom metrics ops

### DIFF
--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -123,7 +123,7 @@ object Metrics {
   )(implicit F: Clock[F], C: Concurrent[F]): Resource[F, Response[F]] =
     (for {
       classifier <- Resource.eval(classifierF(req))
-      _ <- Resource.make(ops.increaseActiveRequests(classifier))(_ =>
+      _ <- Resource.make(ops.increaseActiveRequests(classifier, customLabelValues))(_ =>
         ops.decreaseActiveRequests(classifier, customLabelValues)
       )
       _ <- Resource.onFinalize(

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -66,7 +66,7 @@ object Metrics {
         None
       },
   )(client: Client[F])(implicit F: Clock[F], C: Concurrent[F]): Client[F] =
-    effect(ops, customLabelValues, classifierF.andThen(_.pure[F]))(client)
+    effectWithCustomLabelValues(ops, customLabelValues, classifierF.andThen(_.pure[F]))(client)
 
   /** Wraps a [[Client]] with a middleware capable of recording metrics
     *

--- a/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
+++ b/client/shared/src/main/scala/org/http4s/client/middleware/Metrics.scala
@@ -85,7 +85,7 @@ object Metrics {
   )(implicit F: Clock[F], C: Concurrent[F]): Client[F] =
     Client(withMetrics(client, ops, classifierF, List.empty))
 
-  def effect[F[_]](
+  def effectWithCustomLabelValues[F[_]](
       ops: MetricsOps[F],
       customLabelValues: List[String],
       classifierF: Request[F] => F[Option[String]],

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomLabels.scala
@@ -1,0 +1,21 @@
+package org.http4s.metrics
+
+import org.http4s.util.{SizedSeq, SizedSeq0}
+
+trait CustomLabels[+SL <: SizedSeq[String]] {
+  def labels: SL
+  def values: SL
+}
+
+object CustomLabels {
+  def apply[SL <: SizedSeq[String]](pLabels: SL, pValues: SL): CustomLabels[SL] =
+    new CustomLabels[SL] {
+      override def labels: SL = pLabels
+      override def values: SL = pValues
+    }
+}
+
+case class EmptyCustomLabels() extends CustomLabels[SizedSeq0[String]] {
+  override def labels: SizedSeq0[String] = SizedSeq0[String]()
+  override def values: SizedSeq0[String] = SizedSeq0[String]()
+}

--- a/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/CustomMetricsOps.scala
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2013 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.metrics
+
+import cats.~>
+import org.http4s.util.{SizedSeq, SizedSeq0}
+import org.http4s.{Method, Status}
+
+/** Describes an algebra capable of writing metrics to a metrics registry
+  */
+trait CustomMetricsOps[F[_], SL <: SizedSeq[String]] extends MetricsOps[F] {
+
+  /** @return the custom label object used to define this CustomMetricsOps
+    */
+  def definingCustomLabels: CustomLabels[SL]
+
+  /** Increases the count of active requests
+    *
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def increaseActiveRequests(classifier: Option[String], customLabelValues: SL): F[Unit]
+  override def increaseActiveRequests(classifier: Option[String]): F[Unit] =
+    increaseActiveRequests(classifier, definingCustomLabels.values)
+
+  /** Decreases the count of active requests
+    *
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def decreaseActiveRequests(classifier: Option[String], customLabelValues: SL): F[Unit]
+  override def decreaseActiveRequests(classifier: Option[String]): F[Unit] =
+    decreaseActiveRequests(classifier, definingCustomLabels.values)
+
+  /** Records the time to receive the response headers
+    *
+    * @param method the http method of the request
+    * @param elapsed the time to record
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+  ): F[Unit] = recordHeadersTime(method, elapsed, classifier, definingCustomLabels.values)
+
+  /** Records the time to fully consume the response, including the body
+    *
+    * @param method the http method of the request
+    * @param status the http status code of the response
+    * @param elapsed the time to record
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+  ): F[Unit] = recordTotalTime(method, status, elapsed, classifier, definingCustomLabels.values)
+
+  /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
+    *
+    * @param elapsed the time to record
+    * @param terminationType the type of termination
+    * @param classifier the classifier to apply
+    * @param customLabelValues values for custom labels
+    */
+  def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+      customLabelValues: SL,
+  ): F[Unit]
+  override def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+  ): F[Unit] =
+    recordAbnormalTermination(elapsed, terminationType, classifier, definingCustomLabels.values)
+
+  /** Transform the effect of MetricOps using the supplied natural transformation
+    *
+    * @param fk natural transformation
+    * @tparam G the effect to transform to
+    * @return a new metric ops in the transformed effect
+    */
+  override def mapK[G[_]](fk: F ~> G): CustomMetricsOps[G, SL] = {
+    val ops: CustomMetricsOps[F, SL] = this
+    new CustomMetricsOps[G, SL] {
+      override def definingCustomLabels: CustomLabels[SL] = ops.definingCustomLabels
+      override def increaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.increaseActiveRequests(classifier, customLabelValues))
+
+      override def decreaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.decreaseActiveRequests(classifier, customLabelValues))
+
+      override def recordHeadersTime(
+          method: Method,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier, customLabelValues))
+
+      override def recordTotalTime(
+          method: Method,
+          status: Status,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier, customLabelValues))
+
+      override def recordAbnormalTermination(
+          elapsed: Long,
+          terminationType: TerminationType,
+          classifier: Option[String],
+          customLabelValues: SL,
+      ): G[Unit] =
+        fk(ops.recordAbnormalTermination(elapsed, terminationType, classifier, customLabelValues))
+
+    }
+  }
+}
+
+object CustomMetricsOps {
+  def fromMetricsOps[F[_]](ops: MetricsOps[F]): CustomMetricsOps[F, SizedSeq0[String]] = {
+    val emptyCustomLabels: EmptyCustomLabels = EmptyCustomLabels()
+
+    new CustomMetricsOps[F, SizedSeq0[String]]() {
+
+      override def definingCustomLabels: EmptyCustomLabels = emptyCustomLabels
+
+      override def increaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.increaseActiveRequests(classifier)
+
+      override def decreaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.decreaseActiveRequests(classifier)
+
+      override def recordHeadersTime(
+          method: Method,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordHeadersTime(method, elapsed, classifier)
+
+      override def recordTotalTime(
+          method: Method,
+          status: Status,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordTotalTime(method, status, elapsed, classifier)
+
+      override def recordAbnormalTermination(
+          elapsed: Long,
+          terminationType: TerminationType,
+          classifier: Option[String],
+          customLabelValues: SizedSeq0[String],
+      ): F[Unit] = ops.recordAbnormalTermination(elapsed, terminationType, classifier)
+    }
+  }
+}

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -21,7 +21,6 @@ import cats.~>
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Status
-import org.typelevel.scalaccompat.annotation.nowarn
 
 /** Describes an algebra capable of writing metrics to a metrics registry
   */
@@ -33,23 +32,11 @@ trait MetricsOps[F[_]] {
     */
   def increaseActiveRequests(classifier: Option[String]): F[Unit]
 
-  @nowarn
-  def increaseActiveRequests(
-      classifier: Option[String],
-      customLabelValues: List[String],
-  ): F[Unit] = increaseActiveRequests(classifier)
-
   /** Decreases the count of active requests
     *
     * @param classifier the classifier to apply
     */
   def decreaseActiveRequests(classifier: Option[String]): F[Unit]
-
-  @nowarn
-  def decreaseActiveRequests(
-      classifier: Option[String],
-      customLabelValues: List[String],
-  ): F[Unit] = decreaseActiveRequests(classifier)
 
   /** Records the time to receive the response headers
     *
@@ -58,14 +45,6 @@ trait MetricsOps[F[_]] {
     * @param classifier the classifier to apply
     */
   def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
-
-  @nowarn
-  def recordHeadersTime(
-      method: Method,
-      elapsed: Long,
-      classifier: Option[String],
-      customLabelValues: List[String],
-  ): F[Unit] = recordHeadersTime(method, elapsed, classifier)
 
   /** Records the time to fully consume the response, including the body
     *
@@ -81,15 +60,6 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
-  @nowarn
-  def recordTotalTime(
-      method: Method,
-      status: Status,
-      elapsed: Long,
-      classifier: Option[String],
-      customLabelValues: List[String],
-  ): F[Unit] = recordTotalTime(method, status, elapsed, classifier)
-
   /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
     *
     * @param elapsed the time to record
@@ -101,14 +71,6 @@ trait MetricsOps[F[_]] {
       terminationType: TerminationType,
       classifier: Option[String],
   ): F[Unit]
-
-  @nowarn
-  def recordAbnormalTermination(
-      elapsed: Long,
-      terminationType: TerminationType,
-      classifier: Option[String],
-      customLabelValues: List[String],
-  ): F[Unit] = recordAbnormalTermination(elapsed, terminationType, classifier)
 
   /** Transform the effect of MetricOps using the supplied natural transformation
     *
@@ -122,62 +84,25 @@ trait MetricsOps[F[_]] {
       override def increaseActiveRequests(classifier: Option[String]): G[Unit] = fk(
         ops.increaseActiveRequests(classifier)
       )
-      override def increaseActiveRequests(
-          classifier: Option[String],
-          customLabelValues: List[String],
-      ): G[Unit] = fk(
-        ops.increaseActiveRequests(classifier, customLabelValues)
-      )
-
       override def decreaseActiveRequests(classifier: Option[String]): G[Unit] = fk(
         ops.decreaseActiveRequests(classifier)
       )
-      override def decreaseActiveRequests(
-          classifier: Option[String],
-          customLabelValues: List[String],
-      ): G[Unit] = fk(
-        ops.decreaseActiveRequests(classifier, customLabelValues)
-      )
-
       override def recordHeadersTime(
           method: Method,
           elapsed: Long,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier))
-      override def recordHeadersTime(
-          method: Method,
-          elapsed: Long,
-          classifier: Option[String],
-          customLabelValues: List[String],
-      ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier, customLabelValues))
-
       override def recordTotalTime(
           method: Method,
           status: Status,
           elapsed: Long,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier))
-      override def recordTotalTime(
-          method: Method,
-          status: Status,
-          elapsed: Long,
-          classifier: Option[String],
-          customLabelValues: List[String],
-      ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier, customLabelValues))
-
       override def recordAbnormalTermination(
           elapsed: Long,
           terminationType: TerminationType,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordAbnormalTermination(elapsed, terminationType, classifier))
-      override def recordAbnormalTermination(
-          elapsed: Long,
-          terminationType: TerminationType,
-          classifier: Option[String],
-          customLabelValues: List[String],
-      ): G[Unit] = fk(
-        ops.recordAbnormalTermination(elapsed, terminationType, classifier, customLabelValues)
-      )
     }
   }
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -116,25 +116,62 @@ trait MetricsOps[F[_]] {
       override def increaseActiveRequests(classifier: Option[String]): G[Unit] = fk(
         ops.increaseActiveRequests(classifier)
       )
+      override def increaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: List[String],
+      ): G[Unit] = fk(
+        ops.increaseActiveRequests(classifier, customLabelValues)
+      )
+
       override def decreaseActiveRequests(classifier: Option[String]): G[Unit] = fk(
         ops.decreaseActiveRequests(classifier)
       )
+      override def decreaseActiveRequests(
+          classifier: Option[String],
+          customLabelValues: List[String],
+      ): G[Unit] = fk(
+        ops.decreaseActiveRequests(classifier, customLabelValues)
+      )
+
       override def recordHeadersTime(
           method: Method,
           elapsed: Long,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier))
+      override def recordHeadersTime(
+          method: Method,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: List[String],
+      ): G[Unit] = fk(ops.recordHeadersTime(method, elapsed, classifier, customLabelValues))
+
       override def recordTotalTime(
           method: Method,
           status: Status,
           elapsed: Long,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier))
+      override def recordTotalTime(
+          method: Method,
+          status: Status,
+          elapsed: Long,
+          classifier: Option[String],
+          customLabelValues: List[String],
+      ): G[Unit] = fk(ops.recordTotalTime(method, status, elapsed, classifier, customLabelValues))
+
       override def recordAbnormalTermination(
           elapsed: Long,
           terminationType: TerminationType,
           classifier: Option[String],
       ): G[Unit] = fk(ops.recordAbnormalTermination(elapsed, terminationType, classifier))
+      override def recordAbnormalTermination(
+          elapsed: Long,
+          terminationType: TerminationType,
+          classifier: Option[String],
+          customLabelValues: List[String],
+      ): G[Unit] = fk(
+        ops.recordAbnormalTermination(elapsed, terminationType, classifier, customLabelValues)
+      )
     }
   }
 }

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -32,11 +32,21 @@ trait MetricsOps[F[_]] {
     */
   def increaseActiveRequests(classifier: Option[String]): F[Unit]
 
+  def increaseActiveRequests(
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = increaseActiveRequests(classifier)
+
   /** Decreases the count of active requests
     *
     * @param classifier the classifier to apply
     */
   def decreaseActiveRequests(classifier: Option[String]): F[Unit]
+
+  def decreaseActiveRequests(
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = decreaseActiveRequests(classifier)
 
   /** Records the time to receive the response headers
     *
@@ -45,6 +55,13 @@ trait MetricsOps[F[_]] {
     * @param classifier the classifier to apply
     */
   def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
+
+  def recordHeadersTime(
+      method: Method,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordHeadersTime(method, elapsed, classifier)
 
   /** Records the time to fully consume the response, including the body
     *
@@ -60,6 +77,14 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
+  def recordTotalTime(
+      method: Method,
+      status: Status,
+      elapsed: Long,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordTotalTime(method, status, elapsed, classifier)
+
   /** Record abnormal terminations, like errors, timeouts or just other abnormal terminations.
     *
     * @param elapsed the time to record
@@ -71,6 +96,13 @@ trait MetricsOps[F[_]] {
       terminationType: TerminationType,
       classifier: Option[String],
   ): F[Unit]
+
+  def recordAbnormalTermination(
+      elapsed: Long,
+      terminationType: TerminationType,
+      classifier: Option[String],
+      customLabelValues: List[String],
+  ): F[Unit] = recordAbnormalTermination(elapsed, terminationType, classifier)
 
   /** Transform the effect of MetricOps using the supplied natural transformation
     *

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -21,6 +21,7 @@ import cats.~>
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Status
+import org.typelevel.scalaccompat.annotation.nowarn
 
 /** Describes an algebra capable of writing metrics to a metrics registry
   */
@@ -32,6 +33,7 @@ trait MetricsOps[F[_]] {
     */
   def increaseActiveRequests(classifier: Option[String]): F[Unit]
 
+  @nowarn("cat=unused")
   def increaseActiveRequests(
       classifier: Option[String],
       customLabelValues: List[String],
@@ -43,6 +45,7 @@ trait MetricsOps[F[_]] {
     */
   def decreaseActiveRequests(classifier: Option[String]): F[Unit]
 
+  @nowarn("cat=unused")
   def decreaseActiveRequests(
       classifier: Option[String],
       customLabelValues: List[String],
@@ -56,6 +59,7 @@ trait MetricsOps[F[_]] {
     */
   def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
 
+  @nowarn("cat=unused")
   def recordHeadersTime(
       method: Method,
       elapsed: Long,
@@ -77,6 +81,7 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
+  @nowarn("cat=unused")
   def recordTotalTime(
       method: Method,
       status: Status,
@@ -97,6 +102,7 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
+  @nowarn("cat=unused")
   def recordAbnormalTermination(
       elapsed: Long,
       terminationType: TerminationType,

--- a/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
+++ b/core/shared/src/main/scala/org/http4s/metrics/MetricsOps.scala
@@ -33,7 +33,7 @@ trait MetricsOps[F[_]] {
     */
   def increaseActiveRequests(classifier: Option[String]): F[Unit]
 
-  @nowarn("cat=unused")
+  @nowarn
   def increaseActiveRequests(
       classifier: Option[String],
       customLabelValues: List[String],
@@ -45,7 +45,7 @@ trait MetricsOps[F[_]] {
     */
   def decreaseActiveRequests(classifier: Option[String]): F[Unit]
 
-  @nowarn("cat=unused")
+  @nowarn
   def decreaseActiveRequests(
       classifier: Option[String],
       customLabelValues: List[String],
@@ -59,7 +59,7 @@ trait MetricsOps[F[_]] {
     */
   def recordHeadersTime(method: Method, elapsed: Long, classifier: Option[String]): F[Unit]
 
-  @nowarn("cat=unused")
+  @nowarn
   def recordHeadersTime(
       method: Method,
       elapsed: Long,
@@ -81,7 +81,7 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
-  @nowarn("cat=unused")
+  @nowarn
   def recordTotalTime(
       method: Method,
       status: Status,
@@ -102,7 +102,7 @@ trait MetricsOps[F[_]] {
       classifier: Option[String],
   ): F[Unit]
 
-  @nowarn("cat=unused")
+  @nowarn
   def recordAbnormalTermination(
       elapsed: Long,
       terminationType: TerminationType,

--- a/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
+++ b/core/shared/src/main/scala/org/http4s/util/SizedSeq.scala
@@ -1,0 +1,56 @@
+package org.http4s.util
+
+sealed trait SizedSeq[+A] {
+  def toSeq: Seq[A]
+}
+
+abstract class SizedSeqBase[+A] extends SizedSeq[A] {
+  protected val seq: Seq[A]
+  override def toSeq: Seq[A] = seq
+}
+
+// format: off
+case class SizedSeq0[+A]() extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq.empty
+}
+
+case class SizedSeq1[+A](s1: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1)
+}
+
+case class SizedSeq2[+A](s1: A, s2: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2)
+}
+
+case class SizedSeq3[+A](s1: A, s2: A, s3: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3)
+}
+
+case class SizedSeq4[+A](s1: A, s2: A, s3: A, s4: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4)
+}
+
+case class SizedSeq5[+A](s1: A, s2: A, s3: A, s4: A, s5: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5)
+}
+
+case class SizedSeq6[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6)
+}
+
+case class SizedSeq7[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7)
+}
+
+case class SizedSeq8[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8)
+}
+
+case class SizedSeq9[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9)
+}
+
+case class SizedSeq10[+A](s1: A, s2: A, s3: A, s4: A, s5: A, s6: A, s7: A, s8: A, s9: A, s10: A) extends SizedSeqBase[A] {
+  override val seq: Seq[A] = Seq(s1, s2, s3, s4, s5, s6, s7, s8, s9, s10)
+}
+// format: on

--- a/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
+++ b/server/shared/src/main/scala/org/http4s/server/middleware/Metrics.scala
@@ -72,7 +72,13 @@ object Metrics {
         None
       },
   )(routes: HttpRoutes[F])(implicit F: Clock[F], C: MonadCancel[F, Throwable]): HttpRoutes[F] =
-    effect[F](ops, emptyResponseHandler, errorResponseHandler, classifierF(_).pure[F])(routes)
+    effectWithCustomLabelValues[F](
+      ops,
+      customLabelValues,
+      emptyResponseHandler,
+      errorResponseHandler,
+      classifierF(_).pure[F],
+    )(routes)
 
   /** A server middleware capable of recording metrics
     *


### PR DESCRIPTION
Allow adding custom labels.

**Background**
In a situation where a service interacts with multiple providers, a few of them do not have a lot of traffic, so when one of these light providers is down, the alert of the service is not triggered due to the small percentage counted in the failing traffic; So we want to create alerts specific to providers, and I’m searching for ways to identify the metrics entries related to a provider.
Two options currently available:
- Use provider specific prefix when create `MetricsOps` instance, but the metrics of this client will be excluded from a generic Http4S metrics dashboard;
- Add provider specific prefix to classifier when create `org.http4s.client.middleware.Metrics`.

The second option is better than the first option, but not ideal.

**What it does**
This PR
- Add CustomMetricsOps to allow adding custom labels to metrics records;
- Add the ability to client and server Metrics middleware to call the MetricsOps with custom label values.

Pull request on `http4s-prometheus-metrics` [Allow custom labels](https://github.com/http4s/http4s-prometheus-metrics/pull/167) allows the creation of MetricsOps with custom label.

For binary compatibility, the new methods of `MetricsOps` with the `customLabelValues` parameter come with a default implementation which just calls the existing corresponding method. A PR on `http4s-prometheus-metrics` will provide real implementation of these methods.

Added `withCustomLabelValues` method to both client and server `Metrics` middleware to pass custom label values.

Following this PR, `http4s-prometheus-metrics` PR [Implement calling MetricsOps with custom label values](https://github.com/http4s/http4s-prometheus-metrics/pull/167) will provide real implementation for the new methods.


When CustomMetricsOps with some custom labels is created, the middleware calling it must supply the same number of label values, so the type parameter SL is added.

We could use `shapeless`'s `Sized` type, but `shapeless` is not on the dependency list and it unlikely will be allowed to add it. So we temporarily created `SizedSeq` to mimic `shapeless`'s `Sized` type.

`http4s-prometheus-metrics` is updated to adapt this feature.